### PR TITLE
Negative primaryKey values when inserting rows

### DIFF
--- a/Source/Core/Connection.swift
+++ b/Source/Core/Connection.swift
@@ -102,7 +102,7 @@ public final class Connection {
     /// The last rowid inserted into the database via this connection.
     public var lastInsertRowid: Int64? {
         let rowid = sqlite3_last_insert_rowid(handle)
-        return rowid > 0 ? rowid : nil
+        return rowid != 0 ? rowid : nil
     }
 
     /// The last number of changes (inserts, updates, or deletes) made to the


### PR DESCRIPTION
The sqlite3_last_insert_rowid method is returning the negativ rowid (e.g. -1) and it is still conform with the Zero value for "no rows inserted" as described in the sqlite3 documentation.